### PR TITLE
Position-based rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,12 +133,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "darling"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dict-compare"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "bitflags",
  "clap",
+ "enumset",
  "indexmap",
  "itertools",
  "regex",
@@ -158,10 +193,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
+name = "enumset"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "226c0da7462c13fb57e5cc9e0dc8f0635e7d27f276a3a7fd30054647f669007d"
+dependencies = [
+ "enumset_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08b6c6ab82d70f08844964ba10c7babb716de2ecaeab9be5717918a5177d3af"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "hashbrown"
@@ -174,6 +237,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 anyhow = "1.0.80"
 bitflags = { version = "2.4.2", features = ["serde"] }
 clap = { version = "4.5.1", features = ["derive"] }
+enumset = { version = "1.1.3", features = ["serde"] }
 indexmap = { version = "2.2.3", features = ["serde"] }
 itertools = "0.12.1"
 regex = "1.10.3"

--- a/src/pronounce.rs
+++ b/src/pronounce.rs
@@ -1,6 +1,7 @@
 use std::{cmp, collections::BTreeMap, fmt, io::BufRead, ops::Deref, rc::Rc};
 
 use anyhow::Context;
+use enumset::EnumSetType;
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 
@@ -174,7 +175,8 @@ impl Deref for Phoneme {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[derive(Debug, Ord, PartialOrd, EnumSetType, Deserialize, serde::Serialize)]
+#[enumset(serialize_repr = "list")]
 pub enum Stress {
     None,
     Secondary,

--- a/src/theory.rs
+++ b/src/theory.rs
@@ -945,7 +945,7 @@ mod tests {
     #[test_case("IH0 K S P EH2 N D", "KPEPBD" ; "expend")]
     #[test_case("IH0 K S CH EY2 N JH", "KPHAEUFPBG" ; "exchange")]
     #[test_case("AE1 K SH AH0 N", "ABGS" ; "action")]
-    #[test_case("G AH1 M P SH AH0 N", "TKPW*UPLGS" ; "gumption")]
+    #[test_case("G AH1 M P SH AH0 N", "TKPWUFRPGS" ; "gumption")]
     #[test_case("K AA1 N SH AH0 S", "K-RBS" ; "conscious")]
     #[test_case("D R AO1 IH0 NG", "TKRO/WEUPBG" ; "drawing")]
     fn word_to_outline(pronunciation: &str, expected_outline: &str) -> anyhow::Result<()> {

--- a/theory.yaml
+++ b/theory.yaml
@@ -137,23 +137,30 @@ theory:
       - take_next: "S P"
         stress: ["None"]
         chords: ["KP"]
+        position: ["Initial"]
       - take_next: "S K"
         stress: ["None"]
         chords: ["KP"]
+        position: ["Initial"]
       - take_next: "S T"
         stress: ["None"]
         chords: ["KP"]
+        position: ["Initial"]
       - take_next: "S"
         stress: ["None"]
         chords: ["KP"]
+        position: ["Initial"]
     "IH K S":
       - take_next: "CH"
         stress: ["None"]
         chords: ["KPH"]
+        position: ["Initial"]
     "K AA N":
       - chords: ["K"]
+        position: ["Initial"]
     "K AO N":
       - chords: ["K"]
+        position: ["Initial"]
   suffixes:
     "K SH AH N":
       - stress: ["None"]
@@ -239,6 +246,7 @@ phonology:
       vowel: "AH"
       coda: ""
       stress: ["None"]
+      position: ["Medial"]
     - onset: "K SH"
       vowel: "AH"
       coda: "N"
@@ -247,3 +255,4 @@ phonology:
       vowel: "AH"
       coda: "N"
       stress: ["None"]
+      position: ["Medial", "Final"]

--- a/theory.yaml
+++ b/theory.yaml
@@ -2,7 +2,7 @@ theory:
   vowels:
     "AH":
       - prev: "Y"
-        stress: None
+        stress: ["None"]
         chords: ["AOU"]
       - chords: ["U"]
     "AA":
@@ -23,7 +23,7 @@ theory:
     "EH": ["E"]
     "ER":
       - prev: "Y"
-        stress: None
+        stress: ["None"]
         chords: ["AOUR"]
       - chords: ["UR"]
     "UH":
@@ -72,10 +72,10 @@ theory:
     "W": ["W"]
     "Y":
       - next: "AH"
-        stress: None
+        stress: ["None"]
         chords: [""]
       - next: "ER"
-        stress: None
+        stress: ["None"]
         chords: [""]
       - next: "UH"
         chords: [""]
@@ -135,20 +135,20 @@ theory:
   prefixes:
     "IH K":
       - take_next: "S P"
-        stress: None
+        stress: ["None"]
         chords: ["KP"]
       - take_next: "S K"
-        stress: None
+        stress: ["None"]
         chords: ["KP"]
       - take_next: "S T"
-        stress: None
+        stress: ["None"]
         chords: ["KP"]
       - take_next: "S"
-        stress: None
+        stress: ["None"]
         chords: ["KP"]
     "IH K S":
       - take_next: "CH"
-        stress: None
+        stress: ["None"]
         chords: ["KPH"]
     "K AA N":
       - chords: ["K"]
@@ -156,16 +156,16 @@ theory:
       - chords: ["K"]
   suffixes:
     "K SH AH N":
-      - stress: None
+      - stress: ["None"]
         chords: ["-BGS", "*BGS"]
     "SH AH N":
-      - stress: None
+      - stress: ["None"]
         chords: ["-GS", "*GS"]
     "SH AH S":
-      - stress: None
+      - stress: ["None"]
         chords: ["-RBS", "*RBS"]
     "AH":
-      - stress: None
+      - stress: ["None"]
         chords: ["", "U"]
 
   spelling_conflicts:
@@ -234,16 +234,16 @@ phonology:
     - onset: ""
       vowel: "AH"
       coda: "B AH L"
-      stress: None
+      stress: ["None"]
     - onset: ""
       vowel: "AH"
       coda: ""
-      stress: None
+      stress: ["None"]
     - onset: "K SH"
       vowel: "AH"
       coda: "N"
-      stress: None
+      stress: ["None"]
     - onset: "SH"
       vowel: "AH"
       coda: "N"
-      stress: None
+      stress: ["None"]

--- a/theory.yaml
+++ b/theory.yaml
@@ -133,27 +133,25 @@ theory:
     "L P": ["-P", "-PL"]
 
   prefixes:
-    "IH K":
-      - take_next: "S P"
-        stress: ["None"]
-        chords: ["KP"]
-        position: ["Initial"]
-      - take_next: "S K"
-        stress: ["None"]
-        chords: ["KP"]
-        position: ["Initial"]
-      - take_next: "S T"
-        stress: ["None"]
-        chords: ["KP"]
-        position: ["Initial"]
-      - take_next: "S"
-        stress: ["None"]
-        chords: ["KP"]
-        position: ["Initial"]
     "IH K S":
+      - take_next: "P"
+        stress: ["None"]
+        chords: ["KP"]
+        position: ["Initial"]
+      - take_next: "K"
+        stress: ["None"]
+        chords: ["KP"]
+        position: ["Initial"]
+      - take_next: "T"
+        stress: ["None"]
+        chords: ["KP"]
+        position: ["Initial"]
       - take_next: "CH"
         stress: ["None"]
         chords: ["KPH"]
+        position: ["Initial"]
+      - stress: ["None"]
+        chords: ["KP"]
         position: ["Initial"]
     "K AA N":
       - chords: ["K"]
@@ -161,6 +159,12 @@ theory:
     "K AO N":
       - chords: ["K"]
         position: ["Initial"]
+    "D IH S":
+      - take_next: "T"
+        chords: ["STK"]
+      - take_next: "K"
+        chords: ["STK"]
+      - chords: ["STK"]
   suffixes:
     "K SH AH N":
       - stress: ["None"]
@@ -171,6 +175,14 @@ theory:
     "SH AH S":
       - stress: ["None"]
         chords: ["-RBS", "*RBS"]
+    "S AH Z":
+      - stress: ["None"]
+        position: ["Final"]
+        chords: ["-SZ"]
+    "S IH Z":
+      - stress: ["None"]
+        position: ["Final"]
+        chords: ["-SZ"]
     "AH":
       - stress: ["None"]
         chords: ["", "U"]
@@ -238,6 +250,14 @@ phonology:
   vowels: ["AH", "AA", "AO", "AE", "IH", "EH", "UH", "IY", "EY", "AY", "OY",
     "AW", "OW", "UW", "ER"]
   multi_syllables:
+    - onset: ""
+      vowel: "IH"
+      coda: "K S"
+      stress: ["None"]
+      position: ["Initial"]
+    - onset: "D"
+      vowel: "IH"
+      coda: "S"
     - onset: ""
       vowel: "AH"
       coda: "B AH L"


### PR DESCRIPTION
adds a new `position` field to prefixes, suffixes, and multi-syllables to allow selectively applying them depending on their position in the word.