### PR TITLE
Pesky j clusters

### DIFF
--- a/src/theory.rs
+++ b/src/theory.rs
@@ -317,7 +317,7 @@ pub struct Theory {
     vowels: PronunciationMap<OutputRules>,
     codas: PronunciationMap<OutputRules>,
     #[serde(default)]
-    linkers: BTreeMap<Phoneme, Chord>,
+    linkers: BTreeMap<Pronunciation, Chord>,
     #[serde(default)]
     prefixes: PronunciationMap<Rc<[SyllableRule]>>,
     #[serde(default)]
@@ -785,6 +785,7 @@ impl Phonology {
         vowel += start_at;
         let stress = word[vowel].stress();
         let coda = vowel + 1;
+        vowel = self.vowel_clusters.find(word, start_at..vowel, None);
         // work backwards to find the maximally valid onset
         let onset = self
             .onset_clusters
@@ -899,8 +900,8 @@ impl<'w> Syllable<'w> {
         self.indices.vowel..self.indices.coda
     }
 
-    fn vowel(&self) -> &'w Phoneme {
-        &self.word[self.indices.vowel]
+    fn vowel(&self) -> &'w [Phoneme] {
+        &self.word[self.vowel_range()]
     }
 
     fn coda_range(&self) -> Range<usize> {
@@ -993,6 +994,8 @@ mod tests {
 
     #[test_case("S N UW1 T", &["S N UW1 T"] ; "snoot")]
     #[test_case("S EY1 IH0 NG", &["S EY1/IH0 NG"] ; "saying")]
+    #[test_case("B AE1 K Y AA2 R D", &["B AE1 K/Y AA2 R D"] ; "backyard")]
+    #[test_case("K Y UW1 B", &["K Y UW1 B"] ; "cube")]
     #[test_case("IH0 K S P EH2 N D", &["IH0 K S/P EH2 N D", "IH0 K/S P EH2 N D"]; "expend")]
     #[test_case("IH0 K S CH EY2 N JH", &["IH0 K S/CH EY2 N JH", "IH0 K S/CH EY2 N JH"] ; "exchange")]
     #[test_case("D IH1 S T AH0 N T", &["D IH1 S/T AH0 N T", "D IH1/S T AH0 N T"] ; "distant")]

--- a/theory.yaml
+++ b/theory.yaml
@@ -1,10 +1,6 @@
 theory:
   vowels:
-    "AH":
-      - prev: "Y"
-        stress: ["None"]
-        chords: ["AOU"]
-      - chords: ["U"]
+    "AH": ["U"]
     "AA":
       - next: "L"
         chords: ["AU"]
@@ -21,14 +17,8 @@ theory:
       - chords: ["A"]
     "IH": ["EU"]
     "EH": ["E"]
-    "ER":
-      - prev: "Y"
-        stress: ["None"]
-        chords: ["AOUR"]
-      - chords: ["UR"]
+    "ER": ["UR"]
     "UH":
-      - prev: "Y"
-        chords: ["AOU"]
       - next_broad: "L"
         chords: ["U"]
       - chords: ["AO"]
@@ -44,10 +34,17 @@ theory:
       - next: "L"
         chords: ["O"]
       - chords: ["OE"]
-    "UW":
-      - prev: "Y"
+    "UW": ["AO"]
+    "Y UW": ["AOU"]
+    "Y UH": ["AOU"]
+    "Y AH":
+      - stress: ["None"]
         chords: ["AOU"]
-      - chords: ["AO"]
+      - chords: ["KWRU"]
+    "Y ER":
+      - stress: ["None"]
+        chords: ["AOUR"]
+      - chords: ["KWRUR"]
   linkers:
     "AY": "KWR"
     "EY": "KWR"
@@ -81,18 +78,7 @@ theory:
     "TH": ["TH"]
     "V": ["SPW"]
     "W": ["W"]
-    "Y":
-      - next: "AH"
-        stress: ["None"]
-        chords: [""]
-      - next: "ER"
-        stress: ["None"]
-        chords: [""]
-      - next: "UH"
-        chords: [""]
-      - next: "UW"
-        chords: [""]
-      - chords: ["KWR"]
+    "Y": ["KWR"]
     "Z": ["STK", "S*"]
     "ZH": ["SKH"]
     "HH W": ["WH"]
@@ -255,12 +241,14 @@ phonology:
     # Allow 's' plus voicless stop, nasal, or voicless fricative
     - first: ["S"]
       second: ["P", "T", "K", "M", "N", "F", "TH"]
-    # Allow any consonant other than 'r' or 'w' followed by 'j'
-    - first: ["B", "D", "JH", "F", "G", "HH", "Y", "K", "L", "M", "N", "P",
-      "S", "T", "CH", "V", "Z", "DH", "SH", "ZH", "TH"]
+    # Allow 'nj' clusters :3
+    - first: ["N"]
       second: ["Y"]
   vowels: ["AH", "AA", "AO", "AE", "IH", "EH", "UH", "IY", "EY", "AY", "OY",
     "AW", "OW", "UW", "ER"]
+  vowel_clusters:
+    - first: ["Y"]
+      second: ["UW", "UH", "AH"]
   multi_syllables:
     - onset: ""
       vowel: "IH"


### PR DESCRIPTION
Adds vowel clusters, so that /uw/ /u/ /ə/are allowed to be preceded by /j/ clusters, but other vowels aren't.