### PR TITLE
Compound words

### DIFF
--- a/src/compound_words.rs
+++ b/src/compound_words.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::pronounce::{self, DictionaryEntry};
+use crate::{pronounce::{self, DictionaryEntry, Pronunciation}, dictionary::Word};
 
 #[derive(Debug, serde::Serialize)]
 pub struct CompoundWords {
@@ -12,8 +12,9 @@ impl From<&pronounce::Dictionary> for CompoundWords {
     fn from(dictionary: &pronounce::Dictionary) -> Self {
         let mut entries = BTreeMap::new();
         let mut ambiguous = BTreeMap::new();
-        for entry in dictionary.entries() {
-            let mut splits = get_splits(&entry, dictionary);
+        for (word, pronunciation) in dictionary.entries() {
+            let mut splits = get_splits(word, pronunciation, dictionary);
+            let entry = DictionaryEntry { word: word.clone(), pronunciation: pronunciation.clone() };
             if splits.len() > 1 {
                 ambiguous.insert(entry, splits);
             } else if let Some(split) = splits.pop_first() {
@@ -24,39 +25,50 @@ impl From<&pronounce::Dictionary> for CompoundWords {
     }
 }
 
+pub fn get_unambiguous_split(word: &Word, pronunciation: &Pronunciation, dictionary: &pronounce::Dictionary) -> Option<[DictionaryEntry; 2]> {
+    let mut splits = get_splits(word, pronunciation, dictionary);
+    if splits.len() > 1 {
+        None
+    } else {
+        splits.pop_first()
+    }
+}
+
 fn get_splits(
-    entry: &DictionaryEntry,
+    word: &Word,
+    pronunciation: &Pronunciation,
     dictionary: &pronounce::Dictionary,
 ) -> BTreeSet<[DictionaryEntry; 2]> {
-    if entry.word.is_empty() {
+    if word.is_empty() {
         return BTreeSet::new();
     }
-    (1..(entry.word.len() - 1))
-        .filter_map(|i| get_one_split(entry, dictionary, i))
+    (1..(word.len() - 1))
+        .filter_map(|i| get_one_split(word, pronunciation, dictionary, i))
         .collect()
 }
 
 fn get_one_split(
-    entry: &DictionaryEntry,
+    word: &Word,
+    pronunciation: &Pronunciation,
     dictionary: &pronounce::Dictionary,
     split_idx: usize,
 ) -> Option<[DictionaryEntry; 2]> {
-    let (first_word, second_word) = entry.word.split_at(split_idx);
+    let (first_word, second_word) = word.split_at(split_idx);
     let first_prons = dictionary
         .get(first_word)
         .iter()
-        .filter(|pron| entry.pronunciation.starts_with(pron))
+        .filter(|pron| pronunciation.starts_with(pron))
         .collect::<Vec<_>>();
     let second_prons = dictionary
         .get(second_word)
         .iter()
-        .filter(|pron| entry.pronunciation.ends_with(pron))
+        .filter(|pron| pronunciation.ends_with(pron))
         .collect::<Vec<_>>();
 
     // find a pair of pronunciations that add to make the original. we've already filtered to just
     // the pronunciations that are valid prefixes/suffixes of the original word, so we just need to
     // find a pair whose lengths add up
-    let original_len = entry.pronunciation.len();
+    let original_len = pronunciation.len();
     for first_pron in first_prons {
         let first_len = first_pron.len();
         if let Some(&second_pron) = second_prons

--- a/src/compound_words.rs
+++ b/src/compound_words.rs
@@ -1,0 +1,79 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::pronounce::{self, DictionaryEntry};
+
+#[derive(Debug, serde::Serialize)]
+pub struct CompoundWords {
+    entries: BTreeMap<DictionaryEntry, [DictionaryEntry; 2]>,
+    ambiguous: BTreeMap<DictionaryEntry, BTreeSet<[DictionaryEntry; 2]>>,
+}
+
+impl From<&pronounce::Dictionary> for CompoundWords {
+    fn from(dictionary: &pronounce::Dictionary) -> Self {
+        let mut entries = BTreeMap::new();
+        let mut ambiguous = BTreeMap::new();
+        for entry in dictionary.entries() {
+            let mut splits = get_splits(&entry, dictionary);
+            if splits.len() > 1 {
+                ambiguous.insert(entry, splits);
+            } else if let Some(split) = splits.pop_first() {
+                entries.insert(entry, split);
+            }
+        }
+        Self { entries, ambiguous }
+    }
+}
+
+fn get_splits(
+    entry: &DictionaryEntry,
+    dictionary: &pronounce::Dictionary,
+) -> BTreeSet<[DictionaryEntry; 2]> {
+    if entry.word.is_empty() {
+        return BTreeSet::new();
+    }
+    (1..(entry.word.len() - 1))
+        .filter_map(|i| get_one_split(entry, dictionary, i))
+        .collect()
+}
+
+fn get_one_split(
+    entry: &DictionaryEntry,
+    dictionary: &pronounce::Dictionary,
+    split_idx: usize,
+) -> Option<[DictionaryEntry; 2]> {
+    let (first_word, second_word) = entry.word.split_at(split_idx);
+    let first_prons = dictionary
+        .get(first_word)
+        .iter()
+        .filter(|pron| entry.pronunciation.starts_with(pron))
+        .collect::<Vec<_>>();
+    let second_prons = dictionary
+        .get(second_word)
+        .iter()
+        .filter(|pron| entry.pronunciation.ends_with(pron))
+        .collect::<Vec<_>>();
+
+    // find a pair of pronunciations that add to make the original. we've already filtered to just
+    // the pronunciations that are valid prefixes/suffixes of the original word, so we just need to
+    // find a pair whose lengths add up
+    let original_len = entry.pronunciation.len();
+    for first_pron in first_prons {
+        let first_len = first_pron.len();
+        if let Some(&second_pron) = second_prons
+            .iter()
+            .find(|pron| first_len + pron.len() == original_len)
+        {
+            return Some([
+                DictionaryEntry {
+                    word: first_word.into(),
+                    pronunciation: first_pron.clone(),
+                },
+                DictionaryEntry {
+                    word: second_word.into(),
+                    pronunciation: second_pron.clone(),
+                },
+            ]);
+        }
+    }
+    None
+}

--- a/src/generated.rs
+++ b/src/generated.rs
@@ -2,7 +2,7 @@ use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{chord::Outline, dictionary::Word, pronounce::Pronunciation};
+use crate::{chord::Outline, dictionary::Word, pronounce::{DictionaryEntry, Pronunciation}};
 
 #[derive(Default, Debug, Serialize)]
 pub struct GeneratedDictionary {
@@ -105,12 +105,6 @@ impl Serialize for Dictionary {
         }
         map.end()
     }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize)]
-pub struct DictionaryEntry {
-    pub word: Word,
-    pub pronunciation: Pronunciation,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/pronounce.rs
+++ b/src/pronounce.rs
@@ -51,6 +51,11 @@ impl Dictionary {
             })
         })
     }
+
+    /// Filters the dictionary to only contain words matching the filter
+    pub fn retain_words(&mut self, mut predicate: impl FnMut(&Word) -> bool) {
+        self.entries.retain(|word, _prons| predicate(word))
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize)]

--- a/src/pronounce.rs
+++ b/src/pronounce.rs
@@ -43,12 +43,9 @@ impl Dictionary {
             .unwrap_or(&[])
     }
 
-    pub fn entries(&self) -> impl Iterator<Item = DictionaryEntry> + '_ {
+    pub fn entries(&self) -> impl Iterator<Item = (&Word, &Pronunciation)> {
         self.entries.iter().flat_map(|(word, pronunciations)| {
-            pronunciations.iter().map(|pronunciation| DictionaryEntry {
-                word: word.clone(),
-                pronunciation: pronunciation.clone(),
-            })
+            pronunciations.iter().map(move |pronunciation| (word, pronunciation))
         })
     }
 

--- a/src/pronounce.rs
+++ b/src/pronounce.rs
@@ -36,12 +36,27 @@ impl Dictionary {
         Ok(this)
     }
 
-    pub fn get(&self, word: &Word) -> &[Pronunciation] {
+    pub fn get(&self, word: &str) -> &[Pronunciation] {
         self.entries
             .get(&*word.to_ascii_lowercase())
             .map(|ps| &**ps)
             .unwrap_or(&[])
     }
+
+    pub fn entries(&self) -> impl Iterator<Item = DictionaryEntry> + '_ {
+        self.entries.iter().flat_map(|(word, pronunciations)| {
+            pronunciations.iter().map(|pronunciation| DictionaryEntry {
+                word: word.clone(),
+                pronunciation: pronunciation.clone(),
+            })
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize)]
+pub struct DictionaryEntry {
+    pub word: Word,
+    pub pronunciation: Pronunciation,
 }
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Deserialize)]

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -189,6 +189,10 @@ impl<T> Tree<T> {
             roots: self.roots,
         }
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.roots.is_none()
+    }
 }
 
 impl<T: fmt::Debug> fmt::Debug for Tree<T> {


### PR DESCRIPTION
Splits compound words using a pretty simple algorithm: if there exist two other words in the dictionary, such that concatenating their spellings produces the spelling of the original word, and concatenating their pronunciations produces the pronunciation of the original word, and there's only one way to do this, it's a compound word.